### PR TITLE
Adapted onStateUpdated event hook to receive action as well as state.

### DIFF
--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -74,7 +74,11 @@ export namespace ApiHooksEvents {
   /** TYPES */
 
   export type OnBeforeInitialStateCallback = (testKeys?: ApiHooksStore.TestKeyState) => ApiHooksStore.State | undefined;
-  export type OnStateUpdated = (state: ApiHooksStore.State, testKeys?: ApiHooksStore.TestKeyState) => void;
+  export type OnStateUpdated = (
+    state: ApiHooksStore.State,
+    action?: ApiHooksStore.Actions.GenericAction,
+    testKeys?: ApiHooksStore.TestKeyState
+  ) => void;
   export type OnFetchStart = (endpointID: string, parameters: any, hookType: ApiHooks.HookType) => void;
   export type OnFetchSuccess = (endpointID: string, parameters: any, hookType: ApiHooks.HookType, response: any) => void;
   export type OnFetchError = (endpointID: string, parameters: any, hookType: ApiHooks.HookType, error: any) => void;


### PR DESCRIPTION
The `onStateUpdated` global event hook now receives the action as well as the state. This is useful for projects which use this hook to cache data externally (like in local storage or the file system.)

Rather than just cache state every time it changes, apps now have the ability to choose when to cache externally, so that "is fetching" updates and error updates can be excluded from the external store.

This is to prevent external cache from being hydrated in an error or fetching state, which can break initial renders.

**VERY MINOR BREAKING CHANGE:**

In case anyone was using the `testKeys` being passed in to `onStateUpdated`, they are now passed in as the 3rd argument rather than the 2nd, the new action is now the 2nd arg. This may require a one-line refactor.